### PR TITLE
Reorder import statements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,8 +35,8 @@ const processor = postcss.plugin('modules-extract-imports', function(options) {
         selector: `:import("${path}")`,
         after: "\n",
         nodes: Object.keys(pathImports).map(importedSymbol => postcss.decl({
-          prop: importedSymbol,
-          value: pathImports[importedSymbol],
+          value: importedSymbol,
+          prop: pathImports[importedSymbol],
           before: "\n  "
         }))
       }));

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const processor = postcss.plugin('modules-extract-imports', function(options) {
   return (css) => {
     let imports = {};
     let importIndex = 0;
-    let createImportedName = options && options.createImportedName || ((importName/*, path*/) => `__imported_${importName}_${importIndex++}`);
+    let createImportedName = options && options.createImportedName || ((importName/*, path*/) => `i__imported_${importName}_${importIndex++}`);
 
     // Find any declaration that supports imports
     css.eachDecl(declFilter, (decl) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import postcss from 'postcss';
 
-const declWhitelist = ['extends'],
+const declWhitelist = ['composes'],
   declFilter = new RegExp(`^(${declWhitelist.join('|')})$`),
   matchImports = /^([\w\s]+?)\s+from\s+(?:"([^"]+)"|'([^']+)')$/;
 

--- a/test/custom-import-name.js
+++ b/test/custom-import-name.js
@@ -10,7 +10,7 @@ var processor = require("../");
 describe("custom-import-name", function() {
   it("should allow to provide a custom imported name", function() {
     var input = ":local(.name) { extends: abc from \"def\"; }";
-    var expected = ":import(\"def\") {\n  abc: abc-from-def;\n}\n:local(.name) { extends: abc-from-def; }";
+    var expected = ":import(\"def\") {\n  abc-from-def: abc;\n}\n:local(.name) { extends: abc-from-def; }";
     var pipeline = postcss([processor({
       createImportedName: function(importName, path) { return importName + "-from-" + path; }
     })]);

--- a/test/custom-import-name.js
+++ b/test/custom-import-name.js
@@ -9,8 +9,8 @@ var processor = require("../");
 
 describe("custom-import-name", function() {
   it("should allow to provide a custom imported name", function() {
-    var input = ":local(.name) { extends: abc from \"def\"; }";
-    var expected = ":import(\"def\") {\n  abc-from-def: abc;\n}\n:local(.name) { extends: abc-from-def; }";
+    var input = ":local(.name) { composes: abc from \"def\"; }";
+    var expected = ":import(\"def\") {\n  abc-from-def: abc;\n}\n:local(.name) { composes: abc-from-def; }";
     var pipeline = postcss([processor({
       createImportedName: function(importName, path) { return importName + "-from-" + path; }
     })]);

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -11,7 +11,7 @@ var processor = require("../");
 var pipeline = postcss([processor]);
 
 function normalize(str) {
-  return str.replace(/\r\n?/g, "\n");
+  return str.replace(/\r\n?/g, "\n").replace(/\n$/,'');
 }
 
 describe("test-cases", function() {

--- a/test/test-cases/import-comment/expected.css
+++ b/test/test-cases/import-comment/expected.css
@@ -1,6 +1,6 @@
 /*
 :local(.exportName) {
-  extends: importName from "path/library.css";
+  composes: importName from "path/library.css";
   other: rule;
 }
 */

--- a/test/test-cases/import-comment/source.css
+++ b/test/test-cases/import-comment/source.css
@@ -1,6 +1,6 @@
 /*
 :local(.exportName) {
-  extends: importName from "path/library.css";
+  composes: importName from "path/library.css";
   other: rule;
 }
 */

--- a/test/test-cases/import-consolidate/expected.css
+++ b/test/test-cases/import-consolidate/expected.css
@@ -7,10 +7,10 @@
   i__imported_otherLibImport_3: otherLibImport;
 }
 :local(.exportName) {
-  extends: i__imported_importName_0 i__imported_secondImport_1;
+  composes: i__imported_importName_0 i__imported_secondImport_1;
   other: rule;
 }
 :local(.otherExport) {
-  extends: i__imported_thirdImport_2;
-  extends: i__imported_otherLibImport_3;
+  composes: i__imported_thirdImport_2;
+  composes: i__imported_otherLibImport_3;
 }

--- a/test/test-cases/import-consolidate/expected.css
+++ b/test/test-cases/import-consolidate/expected.css
@@ -1,16 +1,16 @@
 :import("path/library.css") {
-  __imported_importName_0: importName;
-  __imported_secondImport_1: secondImport;
-  __imported_thirdImport_2: thirdImport;
+  i__imported_importName_0: importName;
+  i__imported_secondImport_1: secondImport;
+  i__imported_thirdImport_2: thirdImport;
 }
 :import("path/other-lib.css") {
-  __imported_otherLibImport_3: otherLibImport;
+  i__imported_otherLibImport_3: otherLibImport;
 }
 :local(.exportName) {
-  extends: __imported_importName_0 __imported_secondImport_1;
+  extends: i__imported_importName_0 i__imported_secondImport_1;
   other: rule;
 }
 :local(.otherExport) {
-  extends: __imported_thirdImport_2;
-  extends: __imported_otherLibImport_3;
+  extends: i__imported_thirdImport_2;
+  extends: i__imported_otherLibImport_3;
 }

--- a/test/test-cases/import-consolidate/expected.css
+++ b/test/test-cases/import-consolidate/expected.css
@@ -1,10 +1,10 @@
 :import("path/library.css") {
-  importName: __imported_importName_0;
-  secondImport: __imported_secondImport_1;
-  thirdImport: __imported_thirdImport_2;
+  __imported_importName_0: importName;
+  __imported_secondImport_1: secondImport;
+  __imported_thirdImport_2: thirdImport;
 }
 :import("path/other-lib.css") {
-  otherLibImport: __imported_otherLibImport_3;
+  __imported_otherLibImport_3: otherLibImport;
 }
 :local(.exportName) {
   extends: __imported_importName_0 __imported_secondImport_1;

--- a/test/test-cases/import-consolidate/source.css
+++ b/test/test-cases/import-consolidate/source.css
@@ -1,9 +1,9 @@
 
 :local(.exportName) {
-  extends: importName secondImport from 'path/library.css';
+  composes: importName secondImport from 'path/library.css';
   other: rule;
 }
 :local(.otherExport) {
-  extends: thirdImport from 'path/library.css';
-  extends: otherLibImport from 'path/other-lib.css';
+  composes: thirdImport from 'path/library.css';
+  composes: otherLibImport from 'path/other-lib.css';
 }

--- a/test/test-cases/import-local-extends/expected.css
+++ b/test/test-cases/import-local-extends/expected.css
@@ -1,4 +1,4 @@
 :local(.exportName) {
-  extends: localName;
+  composes: localName;
   other: rule;
 }

--- a/test/test-cases/import-local-extends/source.css
+++ b/test/test-cases/import-local-extends/source.css
@@ -1,4 +1,4 @@
 :local(.exportName) {
-  extends: localName;
+  composes: localName;
   other: rule;
 }

--- a/test/test-cases/import-media/expected.css
+++ b/test/test-cases/import-media/expected.css
@@ -5,13 +5,13 @@
 
 @media screen {
   :local(.exportName) {
-    extends: i__imported_importName_0;
-    extends: i__imported_importName2_1;
+    composes: i__imported_importName_0;
+    composes: i__imported_importName2_1;
     other: rule2;
   }
 }
 
 :local(.exportName) {
-  extends: i__imported_importName_0;
+  composes: i__imported_importName_0;
   other: rule;
 }

--- a/test/test-cases/import-media/expected.css
+++ b/test/test-cases/import-media/expected.css
@@ -1,6 +1,6 @@
 :import("path/library.css") {
-  importName: __imported_importName_0;
-  importName2: __imported_importName2_1;
+  __imported_importName_0: importName;
+  __imported_importName2_1: importName2;
 }
 
 @media screen {

--- a/test/test-cases/import-media/expected.css
+++ b/test/test-cases/import-media/expected.css
@@ -1,17 +1,17 @@
 :import("path/library.css") {
-  __imported_importName_0: importName;
-  __imported_importName2_1: importName2;
+  i__imported_importName_0: importName;
+  i__imported_importName2_1: importName2;
 }
 
 @media screen {
   :local(.exportName) {
-    extends: __imported_importName_0;
-    extends: __imported_importName2_1;
+    extends: i__imported_importName_0;
+    extends: i__imported_importName2_1;
     other: rule2;
   }
 }
 
 :local(.exportName) {
-  extends: __imported_importName_0;
+  extends: i__imported_importName_0;
   other: rule;
 }

--- a/test/test-cases/import-media/source.css
+++ b/test/test-cases/import-media/source.css
@@ -1,12 +1,12 @@
 @media screen {
   :local(.exportName) {
-    extends: importName from "path/library.css";
-    extends: importName2 from "path/library.css";
+    composes: importName from "path/library.css";
+    composes: importName2 from "path/library.css";
     other: rule2;
   }
 }
 
 :local(.exportName) {
-  extends: importName from "path/library.css";
+  composes: importName from "path/library.css";
   other: rule;
 }

--- a/test/test-cases/import-multiple-classes/expected.css
+++ b/test/test-cases/import-multiple-classes/expected.css
@@ -1,5 +1,5 @@
 :import("path/library.css") {
-  importName: __imported_importName_0;
-  secondImport: __imported_secondImport_1;
+  __imported_importName_0: importName;
+  __imported_secondImport_1: secondImport;
 }
 :local(.exportName) { extends: __imported_importName_0 __imported_secondImport_1; other: rule; }

--- a/test/test-cases/import-multiple-classes/expected.css
+++ b/test/test-cases/import-multiple-classes/expected.css
@@ -1,5 +1,5 @@
 :import("path/library.css") {
-  __imported_importName_0: importName;
-  __imported_secondImport_1: secondImport;
+  i__imported_importName_0: importName;
+  i__imported_secondImport_1: secondImport;
 }
-:local(.exportName) { extends: __imported_importName_0 __imported_secondImport_1; other: rule; }
+:local(.exportName) { extends: i__imported_importName_0 i__imported_secondImport_1; other: rule; }

--- a/test/test-cases/import-multiple-classes/expected.css
+++ b/test/test-cases/import-multiple-classes/expected.css
@@ -2,4 +2,4 @@
   i__imported_importName_0: importName;
   i__imported_secondImport_1: secondImport;
 }
-:local(.exportName) { extends: i__imported_importName_0 i__imported_secondImport_1; other: rule; }
+:local(.exportName) { composes: i__imported_importName_0 i__imported_secondImport_1; other: rule; }

--- a/test/test-cases/import-multiple-classes/source.css
+++ b/test/test-cases/import-multiple-classes/source.css
@@ -1,1 +1,1 @@
-:local(.exportName) { extends: importName secondImport from 'path/library.css'; other: rule; }
+:local(.exportName) { composes: importName secondImport from 'path/library.css'; other: rule; }

--- a/test/test-cases/import-multiple-references/expected.css
+++ b/test/test-cases/import-multiple-references/expected.css
@@ -1,13 +1,13 @@
 :import("path/library.css") {
-  importName: __imported_importName_0;
-  secondImport: __imported_secondImport_1;
-  importName2: __imported_importName2_3;
+  __imported_importName_0: importName;
+  __imported_secondImport_1: secondImport;
+  __imported_importName2_3: importName2;
 }
 :import("path/library2.css") {
-  importName: __imported_importName_2;
+  __imported_importName_2: importName;
 }
 :import("path/dep3.css") {
-  thirdDep: __imported_thirdDep_4;
+  __imported_thirdDep_4: thirdDep;
 }
 :local(.exportName) {
   extends: __imported_importName_0 __imported_secondImport_1;

--- a/test/test-cases/import-multiple-references/expected.css
+++ b/test/test-cases/import-multiple-references/expected.css
@@ -10,12 +10,12 @@
   i__imported_thirdDep_4: thirdDep;
 }
 :local(.exportName) {
-  extends: i__imported_importName_0 i__imported_secondImport_1;
-  extends: i__imported_importName_2;
-  extends: i__imported_importName2_3;
+  composes: i__imported_importName_0 i__imported_secondImport_1;
+  composes: i__imported_importName_2;
+  composes: i__imported_importName2_3;
 }
 :local(.exportName2) {
-  extends: i__imported_secondImport_1;
-  extends: i__imported_secondImport_1;
-  extends: i__imported_thirdDep_4;
+  composes: i__imported_secondImport_1;
+  composes: i__imported_secondImport_1;
+  composes: i__imported_thirdDep_4;
 }

--- a/test/test-cases/import-multiple-references/expected.css
+++ b/test/test-cases/import-multiple-references/expected.css
@@ -1,21 +1,21 @@
 :import("path/library.css") {
-  __imported_importName_0: importName;
-  __imported_secondImport_1: secondImport;
-  __imported_importName2_3: importName2;
+  i__imported_importName_0: importName;
+  i__imported_secondImport_1: secondImport;
+  i__imported_importName2_3: importName2;
 }
 :import("path/library2.css") {
-  __imported_importName_2: importName;
+  i__imported_importName_2: importName;
 }
 :import("path/dep3.css") {
-  __imported_thirdDep_4: thirdDep;
+  i__imported_thirdDep_4: thirdDep;
 }
 :local(.exportName) {
-  extends: __imported_importName_0 __imported_secondImport_1;
-  extends: __imported_importName_2;
-  extends: __imported_importName2_3;
+  extends: i__imported_importName_0 i__imported_secondImport_1;
+  extends: i__imported_importName_2;
+  extends: i__imported_importName2_3;
 }
 :local(.exportName2) {
-  extends: __imported_secondImport_1;
-  extends: __imported_secondImport_1;
-  extends: __imported_thirdDep_4;
+  extends: i__imported_secondImport_1;
+  extends: i__imported_secondImport_1;
+  extends: i__imported_thirdDep_4;
 }

--- a/test/test-cases/import-multiple-references/source.css
+++ b/test/test-cases/import-multiple-references/source.css
@@ -1,10 +1,10 @@
 :local(.exportName) {
-  extends: importName secondImport from 'path/library.css';
-  extends: importName from 'path/library2.css';
-  extends: importName2 from 'path/library.css';
+  composes: importName secondImport from 'path/library.css';
+  composes: importName from 'path/library2.css';
+  composes: importName2 from 'path/library.css';
 }
 :local(.exportName2) {
-  extends: secondImport from 'path/library.css';
-  extends: secondImport from 'path/library.css';
-  extends: thirdDep from 'path/dep3.css';
+  composes: secondImport from 'path/library.css';
+  composes: secondImport from 'path/library.css';
+  composes: thirdDep from 'path/dep3.css';
 }

--- a/test/test-cases/import-preserving-order/expected.css
+++ b/test/test-cases/import-preserving-order/expected.css
@@ -1,8 +1,8 @@
 :import("./b.css") {
-  b: __imported_b_0;
+  __imported_b_0: b;
 }
 :import("./c.css") {
-  c: __imported_c_1;
+  __imported_c_1: c;
 }
 .a {
   extends: __imported_b_0;

--- a/test/test-cases/import-preserving-order/expected.css
+++ b/test/test-cases/import-preserving-order/expected.css
@@ -1,11 +1,11 @@
 :import("./b.css") {
-  __imported_b_0: b;
+  i__imported_b_0: b;
 }
 :import("./c.css") {
-  __imported_c_1: c;
+  i__imported_c_1: c;
 }
 .a {
-  extends: __imported_b_0;
-  extends: __imported_c_1;
+  extends: i__imported_b_0;
+  extends: i__imported_c_1;
   color: #aaa;
 }

--- a/test/test-cases/import-preserving-order/expected.css
+++ b/test/test-cases/import-preserving-order/expected.css
@@ -5,7 +5,7 @@
   i__imported_c_1: c;
 }
 .a {
-  extends: i__imported_b_0;
-  extends: i__imported_c_1;
+  composes: i__imported_b_0;
+  composes: i__imported_c_1;
   color: #aaa;
 }

--- a/test/test-cases/import-preserving-order/source.css
+++ b/test/test-cases/import-preserving-order/source.css
@@ -1,5 +1,5 @@
 .a {
-  extends: b from "./b.css";
-  extends: c from "./c.css";
+  composes: b from "./b.css";
+  composes: c from "./c.css";
   color: #aaa;
 }

--- a/test/test-cases/import-single-quotes/expected.css
+++ b/test/test-cases/import-single-quotes/expected.css
@@ -1,5 +1,5 @@
 :import("path/library.css") {
-  importName: __imported_importName_0;
+  __imported_importName_0: importName;
 }
 :local(.exportName) {
   extends: __imported_importName_0;

--- a/test/test-cases/import-single-quotes/expected.css
+++ b/test/test-cases/import-single-quotes/expected.css
@@ -2,6 +2,6 @@
   i__imported_importName_0: importName;
 }
 :local(.exportName) {
-  extends: i__imported_importName_0;
+  composes: i__imported_importName_0;
   other: rule;
 }

--- a/test/test-cases/import-single-quotes/expected.css
+++ b/test/test-cases/import-single-quotes/expected.css
@@ -1,7 +1,7 @@
 :import("path/library.css") {
-  __imported_importName_0: importName;
+  i__imported_importName_0: importName;
 }
 :local(.exportName) {
-  extends: __imported_importName_0;
+  extends: i__imported_importName_0;
   other: rule;
 }

--- a/test/test-cases/import-single-quotes/source.css
+++ b/test/test-cases/import-single-quotes/source.css
@@ -1,4 +1,4 @@
 :local(.exportName) {
-  extends: importName from 'path/library.css';
+  composes: importName from 'path/library.css';
   other: rule;
 }

--- a/test/test-cases/import-spacing/expected.css
+++ b/test/test-cases/import-spacing/expected.css
@@ -1,6 +1,6 @@
 :import("path/library.css") {
-  importName: __imported_importName_0;
-  importName2: __imported_importName2_1;
+  __imported_importName_0: importName;
+  __imported_importName2_1: importName2;
 }
 :local(.exportName) {
   extends: __imported_importName_0;

--- a/test/test-cases/import-spacing/expected.css
+++ b/test/test-cases/import-spacing/expected.css
@@ -1,10 +1,10 @@
 :import("path/library.css") {
-  __imported_importName_0: importName;
-  __imported_importName2_1: importName2;
+  i__imported_importName_0: importName;
+  i__imported_importName2_1: importName2;
 }
 :local(.exportName) {
-  extends: __imported_importName_0;
-  extends: __imported_importName2_1;
-  extends: __imported_importName_0 __imported_importName2_1;
+  extends: i__imported_importName_0;
+  extends: i__imported_importName2_1;
+  extends: i__imported_importName_0 i__imported_importName2_1;
   other: rule;
 }

--- a/test/test-cases/import-spacing/expected.css
+++ b/test/test-cases/import-spacing/expected.css
@@ -3,8 +3,8 @@
   i__imported_importName2_1: importName2;
 }
 :local(.exportName) {
-  extends: i__imported_importName_0;
-  extends: i__imported_importName2_1;
-  extends: i__imported_importName_0 i__imported_importName2_1;
+  composes: i__imported_importName_0;
+  composes: i__imported_importName2_1;
+  composes: i__imported_importName_0 i__imported_importName2_1;
   other: rule;
 }

--- a/test/test-cases/import-spacing/source.css
+++ b/test/test-cases/import-spacing/source.css
@@ -1,6 +1,6 @@
 :local(.exportName) {
-  extends: importName  from   	"path/library.css";
-  extends: importName2 from   	"path/library.css";
-  extends: importName   importName2   from   "path/library.css";
+  composes: importName  from   	"path/library.css";
+  composes: importName2 from   	"path/library.css";
+  composes: importName   importName2   from   "path/library.css";
   other: rule;
 }

--- a/test/test-cases/import-within/expected.css
+++ b/test/test-cases/import-within/expected.css
@@ -1,5 +1,5 @@
 :import("path/library.css") {
-  importName: __imported_importName_0;
+  __imported_importName_0: importName;
 }
 :local(.exportName) {
   extends: __imported_importName_0;

--- a/test/test-cases/import-within/expected.css
+++ b/test/test-cases/import-within/expected.css
@@ -2,6 +2,6 @@
   i__imported_importName_0: importName;
 }
 :local(.exportName) {
-  extends: i__imported_importName_0;
+  composes: i__imported_importName_0;
   other: rule;
 }

--- a/test/test-cases/import-within/expected.css
+++ b/test/test-cases/import-within/expected.css
@@ -1,7 +1,7 @@
 :import("path/library.css") {
-  __imported_importName_0: importName;
+  i__imported_importName_0: importName;
 }
 :local(.exportName) {
-  extends: __imported_importName_0;
+  extends: i__imported_importName_0;
   other: rule;
 }

--- a/test/test-cases/import-within/source.css
+++ b/test/test-cases/import-within/source.css
@@ -1,4 +1,4 @@
 :local(.exportName) {
-  extends: importName from "path/library.css";
+  composes: importName from "path/library.css";
   other: rule;
 }


### PR DESCRIPTION
Following on from the [CSSI Spec](https://github.com/css-modules/css-modules/blob/master/INTERCHANGE_FORMAT.md), the `:import` statement reads a lot better `localAlias: remoteExportedToken` rather than the other way around.