### PR TITLE
Handle "compose: x from global;"

### DIFF
--- a/test/test-cases/composing-globals/expected.css
+++ b/test/test-cases/composing-globals/expected.css
@@ -1,0 +1,1 @@
+:local(.exportName) { composes: global(importName) global(secondImport); other: rule; }

--- a/test/test-cases/composing-globals/source.css
+++ b/test/test-cases/composing-globals/source.css
@@ -1,0 +1,1 @@
+:local(.exportName) { composes: importName secondImport from global; other: rule; }


### PR DESCRIPTION
got `x from global` meaning `global(x)`